### PR TITLE
feat: key service and message service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "rustc-hash 2.1.0",
  "serde",
@@ -343,7 +343,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand",
+ "rand 0.8.5",
  "thiserror 2.0.11",
 ]
 
@@ -633,7 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -643,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -719,38 +719,6 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "tokio",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
@@ -759,10 +727,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -775,7 +743,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -793,10 +761,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -809,29 +777,12 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -843,13 +794,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -863,13 +814,13 @@ checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -885,7 +836,7 @@ dependencies = [
  "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -1108,7 +1059,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1301,7 +1252,7 @@ checksum = "0970073d9e74fc74a417c5157146bbc122462c1dc7b2d5c442fe0b67be40e2cb"
 dependencies = [
  "async-trait",
  "celestia-types",
- "http 1.2.0",
+ "http",
  "jsonrpsee",
  "prost 0.13.4",
  "serde",
@@ -1375,7 +1326,9 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1626,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1638,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1669,7 +1622,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
@@ -1878,31 +1831,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1954,7 +1887,7 @@ checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
 dependencies = [
  "digest 0.10.7",
  "futures",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "thiserror 1.0.69",
  "tokio",
@@ -1999,7 +1932,7 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "thiserror 1.0.69",
@@ -2032,7 +1965,7 @@ dependencies = [
  "group 0.13.0",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle",
@@ -2152,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2165,7 +2098,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2192,7 +2125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2451,7 +2384,7 @@ checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2462,7 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2477,7 +2410,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http",
  "indexmap 2.7.1",
  "slab",
  "tokio",
@@ -2504,7 +2437,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pasta_curves 0.4.1",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
 ]
 
@@ -2599,17 +2532,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -2621,23 +2543,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -2648,16 +2559,10 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -2679,29 +2584,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.8",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -2710,8 +2592,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2728,8 +2610,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
  "rustls",
@@ -2746,7 +2628,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2762,9 +2644,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -3181,7 +3063,7 @@ checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.2.0",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -3206,8 +3088,8 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "pin-project",
@@ -3228,8 +3110,8 @@ checksum = "87c24e981ad17798bbca852b0738bfb7b94816ed687bd0d5da60bfa35fa0fdc3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -3264,7 +3146,7 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
 dependencies = [
- "http 1.2.0",
+ "http",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3276,7 +3158,7 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
 dependencies = [
- "http 1.2.0",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3293,7 +3175,7 @@ dependencies = [
  "bls12_381",
  "ff 0.12.1",
  "group 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3353,7 +3235,7 @@ dependencies = [
  "hex",
  "keyring",
  "mockall",
- "rand",
+ "rand 0.8.5",
  "security-framework 3.2.0",
 ]
 
@@ -4038,7 +3920,7 @@ dependencies = [
  "p3-mds",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -4053,7 +3935,7 @@ dependencies = [
  "p3-field",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -4108,7 +3990,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "p3-util",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -4166,7 +4048,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.8.5",
  "serde",
  "tracing",
 ]
@@ -4192,7 +4074,7 @@ dependencies = [
  "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4222,7 +4104,7 @@ dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -4333,7 +4215,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -4348,7 +4230,7 @@ dependencies = [
  "ff 0.13.0",
  "group 0.13.0",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -4485,7 +4367,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4563,9 +4445,10 @@ dependencies = [
  "celestia-types",
  "prism-keys",
  "prism-serde",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
+ "utoipa",
 ]
 
 [[package]]
@@ -4603,10 +4486,11 @@ dependencies = [
  "ed25519-consensus",
  "p256",
  "prism-serde",
- "rand",
+ "rand 0.8.5",
  "secp256k1",
  "serde",
  "sha2 0.10.8",
+ "utoipa",
 ]
 
 [[package]]
@@ -4615,6 +4499,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
+ "chrono",
  "keystore-rs",
  "log",
  "mockall",
@@ -4627,10 +4512,11 @@ dependencies = [
  "prism-tree",
  "serde",
  "tokio",
- "tower-http 0.6.2",
- "utoipa 5.3.1",
+ "tower-http",
+ "utoipa",
  "utoipa-axum",
- "utoipa-swagger-ui 9.0.0",
+ "utoipa-swagger-ui",
+ "uuid",
 ]
 
 [[package]]
@@ -4638,7 +4524,7 @@ name = "prism-prover"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.6.20",
+ "axum 0.8.1",
  "jmt",
  "log",
  "prism-common",
@@ -4650,9 +4536,10 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "tower-http 0.4.4",
- "utoipa 3.5.0",
- "utoipa-swagger-ui 3.1.5",
+ "tower-http",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -4696,6 +4583,7 @@ dependencies = [
  "prism-serde",
  "serde",
  "sha2 0.10.8",
+ "utoipa",
 ]
 
 [[package]]
@@ -4715,30 +4603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit 0.22.23",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4783,8 +4647,8 @@ dependencies = [
  "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -4948,7 +4812,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
  "rustls",
@@ -4996,9 +4860,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -5008,7 +4883,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -5021,12 +4906,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.16",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5147,10 +5042,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -5167,7 +5062,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -5190,7 +5085,7 @@ checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.2.0",
+ "http",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
@@ -5280,7 +5175,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -5296,37 +5191,12 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
-dependencies = [
- "rust-embed-impl 6.8.1",
- "rust-embed-utils 7.8.1",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed"
 version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "rust-embed-impl 8.5.0",
- "rust-embed-utils 8.5.0",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "6.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils 7.8.1",
- "shellexpand",
- "syn 2.0.98",
+ "rust-embed-impl",
+ "rust-embed-utils",
  "walkdir",
 ]
 
@@ -5338,18 +5208,8 @@ checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils 8.5.0",
+ "rust-embed-utils",
  "syn 2.0.98",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "7.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
-dependencies = [
- "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -5622,7 +5482,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
@@ -5889,15 +5749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
-dependencies = [
- "dirs 4.0.0",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5919,7 +5770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5993,7 +5844,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
@@ -6007,7 +5858,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
- "dirs 5.0.1",
+ "dirs",
 ]
 
 [[package]]
@@ -6032,7 +5883,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.8.5",
  "rrs-succinct",
  "serde",
  "serde_json",
@@ -6082,7 +5933,7 @@ dependencies = [
  "p3-uni-stark",
  "p3-util",
  "pathdiff",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "rayon-scan",
  "serde",
@@ -6182,7 +6033,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
- "dirs 5.0.1",
+ "dirs",
  "downloader",
  "eyre",
  "hex",
@@ -6236,7 +6087,7 @@ dependencies = [
  "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "sp1-core-executor",
@@ -6302,7 +6153,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "pathdiff",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sp1-core-machine",
  "sp1-derive",
@@ -6366,7 +6217,7 @@ dependencies = [
  "backoff",
  "bincode",
  "cfg-if",
- "dirs 5.0.1",
+ "dirs",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -6556,12 +6407,6 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -6925,10 +6770,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6957,7 +6802,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -6975,29 +6820,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.8.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -7008,7 +6835,7 @@ checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
- "http 1.2.0",
+ "http",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -7128,9 +6955,9 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "futures",
- "http 1.2.0",
+ "http",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "prost 0.13.4",
  "reqwest",
  "serde",
@@ -7254,18 +7081,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82b1bc5417102a73e8464c686eef947bdfb99fcdfc0a4f228e81afa9526470a"
-dependencies = [
- "indexmap 2.7.1",
- "serde",
- "serde_json",
- "utoipa-gen 3.5.0",
-]
-
-[[package]]
-name = "utoipa"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
@@ -7273,7 +7088,7 @@ dependencies = [
  "indexmap 2.7.1",
  "serde",
  "serde_json",
- "utoipa-gen 5.3.1",
+ "utoipa-gen",
 ]
 
 [[package]]
@@ -7286,20 +7101,7 @@ dependencies = [
  "paste",
  "tower-layer",
  "tower-service",
- "utoipa 5.3.1",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d96dcd6fc96f3df9b3280ef480770af1b7c5d14bc55192baa9b067976d920c"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.98",
+ "utoipa",
 ]
 
 [[package]]
@@ -7316,22 +7118,6 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "3.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84614caa239fb25b2bb373a52859ffd94605ceb256eeb1d63436325cf81e3653"
-dependencies = [
- "axum 0.6.20",
- "mime_guess",
- "regex",
- "rust-embed 6.8.1",
- "serde",
- "serde_json",
- "utoipa 3.5.0",
- "zip 0.6.6",
-]
-
-[[package]]
-name = "utoipa-swagger-ui"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161166ec520c50144922a625d8bc4925cc801b2dda958ab69878527c0e5c5d61"
@@ -7340,12 +7126,22 @@ dependencies = [
  "base64 0.22.1",
  "mime_guess",
  "regex",
- "rust-embed 8.5.0",
+ "rust-embed",
  "serde",
  "serde_json",
  "url",
- "utoipa 5.3.1",
- "zip 2.2.2",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
+name = "uuid"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "getrandom 0.3.1",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -7851,7 +7647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+dependencies = [
+ "zerocopy-derive 0.8.16",
 ]
 
 [[package]]
@@ -7859,6 +7664,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7930,18 +7746,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]
-
-[[package]]
-name = "zip"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
@@ -7977,7 +7781,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "pasta_curves 0.5.1",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,38 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
@@ -727,10 +759,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -743,7 +775,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -761,10 +793,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -777,12 +809,29 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -794,13 +843,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -814,13 +863,13 @@ checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1252,7 +1301,7 @@ checksum = "0970073d9e74fc74a417c5157146bbc122462c1dc7b2d5c442fe0b67be40e2cb"
 dependencies = [
  "async-trait",
  "celestia-types",
- "http",
+ "http 1.2.0",
  "jsonrpsee",
  "prost 0.13.4",
  "serde",
@@ -1829,11 +1878,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2408,7 +2477,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.2.0",
  "indexmap 2.7.1",
  "slab",
  "tokio",
@@ -2530,6 +2599,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -2541,12 +2621,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -2557,10 +2648,16 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -2582,6 +2679,29 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.8",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -2590,8 +2710,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2608,8 +2728,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.2.0",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls",
@@ -2626,7 +2746,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2642,9 +2762,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -3061,7 +3181,7 @@ checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http",
+ "http 1.2.0",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -3086,8 +3206,8 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "pin-project",
@@ -3108,8 +3228,8 @@ checksum = "87c24e981ad17798bbca852b0738bfb7b94816ed687bd0d5da60bfa35fa0fdc3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -3144,7 +3264,7 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
 dependencies = [
- "http",
+ "http 1.2.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3156,7 +3276,7 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
 dependencies = [
- "http",
+ "http 1.2.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4446,7 +4566,6 @@ dependencies = [
  "rand",
  "serde",
  "sha2 0.10.8",
- "utoipa",
 ]
 
 [[package]]
@@ -4488,7 +4607,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2 0.10.8",
- "utoipa",
 ]
 
 [[package]]
@@ -4509,10 +4627,10 @@ dependencies = [
  "prism-tree",
  "serde",
  "tokio",
- "tower-http",
- "utoipa",
+ "tower-http 0.6.2",
+ "utoipa 5.3.1",
  "utoipa-axum",
- "utoipa-swagger-ui",
+ "utoipa-swagger-ui 9.0.0",
 ]
 
 [[package]]
@@ -4520,7 +4638,7 @@ name = "prism-prover"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.8.1",
+ "axum 0.6.20",
  "jmt",
  "log",
  "prism-common",
@@ -4532,10 +4650,9 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "tower-http",
- "utoipa",
- "utoipa-axum",
- "utoipa-swagger-ui",
+ "tower-http 0.4.4",
+ "utoipa 3.5.0",
+ "utoipa-swagger-ui 3.1.5",
 ]
 
 [[package]]
@@ -4579,7 +4696,6 @@ dependencies = [
  "prism-serde",
  "serde",
  "sha2 0.10.8",
- "utoipa",
 ]
 
 [[package]]
@@ -4599,6 +4715,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit 0.22.23",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -5007,10 +5147,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -5027,7 +5167,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -5050,7 +5190,7 @@ checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 1.2.0",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
@@ -5156,12 +5296,37 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+dependencies = [
+ "rust-embed-impl 6.8.1",
+ "rust-embed-utils 7.8.1",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed"
 version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
+ "rust-embed-impl 8.5.0",
+ "rust-embed-utils 8.5.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils 7.8.1",
+ "shellexpand",
+ "syn 2.0.98",
  "walkdir",
 ]
 
@@ -5173,8 +5338,18 @@ checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
- "rust-embed-utils",
+ "rust-embed-utils 8.5.0",
  "syn 2.0.98",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+dependencies = [
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -5714,6 +5889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5823,7 +6007,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
- "dirs",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -5998,7 +6182,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "downloader",
  "eyre",
  "hex",
@@ -6182,7 +6366,7 @@ dependencies = [
  "backoff",
  "bincode",
  "cfg-if",
- "dirs",
+ "dirs 5.0.1",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -6372,6 +6556,12 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -6735,10 +6925,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6785,11 +6975,29 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -6800,7 +7008,7 @@ checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
- "http",
+ "http 1.2.0",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -6920,9 +7128,9 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "futures",
- "http",
+ "http 1.2.0",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "prost 0.13.4",
  "reqwest",
  "serde",
@@ -7046,6 +7254,18 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82b1bc5417102a73e8464c686eef947bdfb99fcdfc0a4f228e81afa9526470a"
+dependencies = [
+ "indexmap 2.7.1",
+ "serde",
+ "serde_json",
+ "utoipa-gen 3.5.0",
+]
+
+[[package]]
+name = "utoipa"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
@@ -7053,7 +7273,7 @@ dependencies = [
  "indexmap 2.7.1",
  "serde",
  "serde_json",
- "utoipa-gen",
+ "utoipa-gen 5.3.1",
 ]
 
 [[package]]
@@ -7066,7 +7286,20 @@ dependencies = [
  "paste",
  "tower-layer",
  "tower-service",
- "utoipa",
+ "utoipa 5.3.1",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d96dcd6fc96f3df9b3280ef480770af1b7c5d14bc55192baa9b067976d920c"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7083,6 +7316,22 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84614caa239fb25b2bb373a52859ffd94605ceb256eeb1d63436325cf81e3653"
+dependencies = [
+ "axum 0.6.20",
+ "mime_guess",
+ "regex",
+ "rust-embed 6.8.1",
+ "serde",
+ "serde_json",
+ "utoipa 3.5.0",
+ "zip 0.6.6",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161166ec520c50144922a625d8bc4925cc801b2dda958ab69878527c0e5c5d61"
@@ -7091,12 +7340,12 @@ dependencies = [
  "base64 0.22.1",
  "mime_guess",
  "regex",
- "rust-embed",
+ "rust-embed 8.5.0",
  "serde",
  "serde_json",
  "url",
- "utoipa",
- "zip",
+ "utoipa 5.3.1",
+ "zip 2.2.2",
 ]
 
 [[package]]
@@ -7677,6 +7926,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7114,6 +7114,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.98",
+ "uuid",
 ]
 
 [[package]]
@@ -7142,6 +7143,7 @@ checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
  "getrandom 0.3.1",
  "rand 0.9.0",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ pretty_env_logger = "0.5.0"
 
 # Serialization/Deserialization
 serde = { version = "1.0.151", features = ["derive"] }
+uuid = { version = "1.13.1", features = [
+    "v4",       # Lets you generate random UUIDs
+    "fast-rng", # Use a faster (but still sufficiently random) RNG
+] }
 
 # Testing
 mockall = "0.13.1"
+chrono = "0.4.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 
 # OAS Documentation
-utoipa = { version = "5.3", features = ["axum_extras"] }
+utoipa = { version = "5.3", features = ["axum_extras", "uuid"] }
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
 utoipa-axum = { version = "0.2.0" }
 
@@ -35,6 +35,7 @@ pretty_env_logger = "0.5.0"
 # Serialization/Deserialization
 serde = { version = "1.0.151", features = ["derive"] }
 uuid = { version = "1.13.1", features = [
+    "serde",
     "v4",       # Lets you generate random UUIDs
     "fast-rng", # Use a faster (but still sufficiently random) RNG
 ] }

--- a/src/account/router.rs
+++ b/src/account/router.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
+use std::sync::Arc;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;

--- a/src/database/inmemory.rs
+++ b/src/database/inmemory.rs
@@ -2,13 +2,14 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use crate::keys::{
-    database::KeyDatabase,
-    entities::{KeyBundle, Prekey},
-};
 use crate::messages::service::Message;
-
-use super::Database;
+use crate::{
+    keys::{
+        database::KeyDatabase,
+        entities::{KeyBundle, Prekey},
+    },
+    messages::database::MessageDatabase,
+};
 
 pub struct InMemoryDatabase {
     pub key_bundles: Mutex<HashMap<String, KeyBundle>>,
@@ -59,7 +60,7 @@ impl KeyDatabase for InMemoryDatabase {
     }
 }
 
-impl Database for InMemoryDatabase {
+impl MessageDatabase for InMemoryDatabase {
     fn insert_message(&self, message: Message) -> Result<bool> {
         let user = message.recipient_id.clone();
         let mut messages_lock = self

--- a/src/database/inmemory.rs
+++ b/src/database/inmemory.rs
@@ -2,9 +2,13 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use super::Database;
-use crate::keys::service::{KeyBundle, Prekey};
+use crate::keys::{
+    database::KeyDatabase,
+    entities::{KeyBundle, Prekey},
+};
 use crate::messages::service::Message;
+
+use super::Database;
 
 pub struct InMemoryDatabase {
     pub key_bundles: Mutex<HashMap<String, KeyBundle>>,
@@ -20,7 +24,7 @@ impl InMemoryDatabase {
     }
 }
 
-impl Database for InMemoryDatabase {
+impl KeyDatabase for InMemoryDatabase {
     fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool> {
         let mut kb_lock = self
             .key_bundles
@@ -53,7 +57,9 @@ impl Database for InMemoryDatabase {
             Err(anyhow!("Key bundle not found for user: {}", user))
         }
     }
+}
 
+impl Database for InMemoryDatabase {
     fn insert_message(&self, message: Message) -> Result<bool> {
         let user = message.recipient_id.clone();
         let mut messages_lock = self

--- a/src/database/inmemory.rs
+++ b/src/database/inmemory.rs
@@ -1,0 +1,93 @@
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::Database;
+use crate::keys::service::{KeyBundle, Prekey};
+use crate::messages::service::Message;
+
+pub struct InMemoryDatabase {
+    pub key_bundles: Mutex<HashMap<String, KeyBundle>>,
+    pub messages: Mutex<HashMap<String, Vec<Message>>>,
+}
+
+impl InMemoryDatabase {
+    pub fn new() -> Self {
+        InMemoryDatabase {
+            key_bundles: Mutex::new(HashMap::new()),
+            messages: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Database for InMemoryDatabase {
+    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool> {
+        let mut kb_lock = self
+            .key_bundles
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+        kb_lock.insert(user, key_bundle);
+        Ok(true)
+    }
+
+    fn get_keybundle(&self, user: String) -> Result<Option<KeyBundle>> {
+        let kb_lock = self
+            .key_bundles
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+        // Return a clone of the key bundle if it exists.
+        Ok(kb_lock.get(&user).cloned())
+    }
+
+    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<bool> {
+        let mut kb_lock = self
+            .key_bundles
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+
+        if let Some(bundle) = kb_lock.get_mut(&user) {
+            // TODO: Ensure no duplicate prekey ids are added.
+            bundle.prekeys.extend(prekeys);
+            Ok(true)
+        } else {
+            Err(anyhow!("Key bundle not found for user: {}", user))
+        }
+    }
+
+    fn insert_message(&self, message: Message) -> Result<bool> {
+        let user = message.recipient_id.clone();
+        let mut messages_lock = self
+            .messages
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+        messages_lock
+            .entry(user)
+            .or_insert_with(Vec::new)
+            .push(message);
+        Ok(true)
+    }
+
+    fn get_messages(&self, user: String) -> Result<Vec<Message>> {
+        let messages_lock = self
+            .messages
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+        // Return a cloned vector of messages (if any) so that users can work on their own copy.
+        Ok(messages_lock.get(&user).cloned().unwrap_or_default())
+    }
+
+    fn mark_delivered(&self, user: String, ids: Vec<uuid::Uuid>) -> Result<bool> {
+        let mut messages_lock = self
+            .messages
+            .lock()
+            .map_err(|e| anyhow!("Lock poisoned: {}", e))?;
+        if let Some(messages) = messages_lock.get_mut(&user) {
+            let original_len = messages.len();
+            // Remove any messages whose message_id is in ids
+            messages.retain(|msg| !ids.contains(&msg.message_id));
+            Ok(messages.len() != original_len)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/database/inmemory.rs
+++ b/src/database/inmemory.rs
@@ -2,13 +2,12 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use crate::messages::service::Message;
 use crate::{
     keys::{
         database::KeyDatabase,
         entities::{KeyBundle, Prekey},
     },
-    messages::database::MessageDatabase,
+    messages::{database::MessageDatabase, entities::Message},
 };
 
 pub struct InMemoryDatabase {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,10 +1,17 @@
+mod inmemory;
 use anyhow::Result;
 
-use crate::keys::service::{KeyBundle, Prekey};
+use crate::{
+    keys::service::{KeyBundle, Prekey},
+    messages::service::Message,
+};
 
 pub trait Database {
-    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<()>;
+    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool>;
     fn get_keybundle(&self, user: String) -> Result<Option<KeyBundle>>;
-    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<()>;
-    // TODO: Messages
+    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<bool>;
+
+    fn insert_message(&self, message: Message) -> Result<bool>;
+    fn get_messages(&self, user: String) -> Result<Vec<Message>>;
+    fn mark_delivered(&self, user: String, ids: Vec<uuid::Uuid>) -> Result<bool>;
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,4 @@
-mod inmemory;
+pub mod inmemory;
 use anyhow::Result;
 
 use crate::{

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,16 +1,9 @@
 pub mod inmemory;
 use anyhow::Result;
 
-use crate::{
-    keys::service::{KeyBundle, Prekey},
-    messages::service::Message,
-};
+use crate::messages::service::Message;
 
 pub trait Database {
-    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool>;
-    fn get_keybundle(&self, user: String) -> Result<Option<KeyBundle>>;
-    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<bool>;
-
     fn insert_message(&self, message: Message) -> Result<bool>;
     fn get_messages(&self, user: String) -> Result<Vec<Message>>;
     fn mark_delivered(&self, user: String, ids: Vec<uuid::Uuid>) -> Result<bool>;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,10 +1,1 @@
 pub mod inmemory;
-use anyhow::Result;
-
-use crate::messages::service::Message;
-
-pub trait Database {
-    fn insert_message(&self, message: Message) -> Result<bool>;
-    fn get_messages(&self, user: String) -> Result<Vec<Message>>;
-    fn mark_delivered(&self, user: String, ids: Vec<uuid::Uuid>) -> Result<bool>;
-}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+
+use crate::keys::service::{KeyBundle, Prekey};
+
+pub trait Database {
+    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<()>;
+    fn get_keybundle(&self, user: String) -> Result<Option<KeyBundle>>;
+    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<()>;
+    // TODO: Messages
+}

--- a/src/keys/database.rs
+++ b/src/keys/database.rs
@@ -1,0 +1,8 @@
+use super::entities::{KeyBundle, Prekey};
+use anyhow::Result;
+
+pub trait KeyDatabase {
+    fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool>;
+    fn get_keybundle(&self, user: String) -> Result<Option<KeyBundle>>;
+    fn add_prekeys(&self, user: String, prekeys: Vec<Prekey>) -> Result<bool>;
+}

--- a/src/keys/database.rs
+++ b/src/keys/database.rs
@@ -1,5 +1,6 @@
-use super::entities::{KeyBundle, Prekey};
 use anyhow::Result;
+
+use super::entities::{KeyBundle, Prekey};
 
 pub trait KeyDatabase {
     fn insert_keybundle(&self, user: String, key_bundle: KeyBundle) -> Result<bool>;

--- a/src/keys/entities.rs
+++ b/src/keys/entities.rs
@@ -1,0 +1,27 @@
+use prism_keys::{Signature, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+pub struct Prekey {
+    pub key_idx: u32,
+    pub key: VerifyingKey,
+}
+
+/// The complete key bundle contains the long-term identity key,
+/// the signed pre-key (with its signature), and a list of one-time pre-keys.
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+pub struct KeyBundle {
+    pub identity_key: VerifyingKey,
+    pub signed_prekey: VerifyingKey,
+    pub signed_prekey_signature: Signature,
+    pub prekeys: Vec<Prekey>,
+}
+
+impl KeyBundle {
+    pub fn verify(&self) {
+        // Ensure signature is signed_prekey signed by identity_key
+        // Ensure prekeys have no duplicate IDs
+        todo!()
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,1 +1,2 @@
+pub mod router;
 pub mod service;

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,4 +1,7 @@
-mod router;
+pub mod database;
+pub mod entities;
 pub mod service;
+
+mod router;
 
 pub use router::router;

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,2 +1,4 @@
-pub mod router;
+mod router;
 pub mod service;
+
+pub use router::router;

--- a/src/keys/router.rs
+++ b/src/keys/router.rs
@@ -9,12 +9,11 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::state::AppState;
-
 use super::{
     entities::{KeyBundle, Prekey},
     service::KeyBundleResponse,
 };
+use crate::state::AppState;
 
 const KEY_TAG: &str = "keys";
 

--- a/src/keys/router.rs
+++ b/src/keys/router.rs
@@ -36,7 +36,7 @@ pub fn router() -> OpenApiRouter<Arc<AppState>> {
 
 #[utoipa::path(
     post,
-    path = "/keys/upload_bundle",
+    path = "/upload_bundle",
     request_body = UploadKeyBundleRequest,
     responses(
         (status = 200, description = "Bundle upload successful"),
@@ -58,7 +58,7 @@ async fn post_keybundle(
 
 #[utoipa::path(
     post,
-    path = "/keys/upload_prekeys",
+    path = "/upload_prekeys",
     request_body = UploadPrekeysRequest,
     responses(
         (status = 200, description = "Prekey upload successful"),
@@ -80,7 +80,7 @@ async fn post_prekeys(
 
 #[utoipa::path(
     get,
-    path = "/keys/bundle/{user_id}",
+    path = "/bundle/{user_id}",
     params(
         ("user_id" = String, Path, description = "User identifier")
     ),

--- a/src/keys/router.rs
+++ b/src/keys/router.rs
@@ -11,7 +11,10 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 
-use super::service::{KeyBundle, KeyBundleResponse, Prekey};
+use super::{
+    entities::{KeyBundle, Prekey},
+    service::KeyBundleResponse,
+};
 
 const KEY_TAG: &str = "keys";
 

--- a/src/keys/router.rs
+++ b/src/keys/router.rs
@@ -53,7 +53,7 @@ async fn post_keybundle(
     state
         .key_service
         .upload_key_bundle(&req.user_id, req.keybundle)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(())
 }
@@ -75,7 +75,7 @@ async fn post_prekeys(
     state
         .key_service
         .add_prekeys(&req.user_id, req.prekeys)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(())
 }

--- a/src/keys/router.rs
+++ b/src/keys/router.rs
@@ -1,0 +1,103 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::state::AppState;
+
+use super::service::{KeyBundle, KeyBundleResponse, Prekey};
+
+const KEY_TAG: &str = "keys";
+
+#[derive(Deserialize, ToSchema)]
+pub struct UploadKeyBundleRequest {
+    pub user_id: String,
+    pub keybundle: KeyBundle,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct UploadPrekeysRequest {
+    pub user_id: String,
+    pub prekeys: Vec<Prekey>,
+}
+
+pub fn router() -> OpenApiRouter<Arc<AppState>> {
+    OpenApiRouter::new()
+        .routes(routes!(post_keybundle))
+        .routes(routes!(get_keybundle))
+        .routes(routes!(post_prekeys))
+}
+
+#[utoipa::path(
+    post,
+    path = "/keys/upload_bundle",
+    request_body = UploadKeyBundleRequest,
+    responses(
+        (status = 200, description = "Bundle upload successful"),
+        (status = 500, description = "Bundle upload failed unexpectedly")
+    ),
+    tag = KEY_TAG
+)]
+async fn post_keybundle(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<UploadKeyBundleRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .key_service
+        .upload_key_bundle(&req.user_id, req.keybundle)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/keys/upload_prekeys",
+    request_body = UploadPrekeysRequest,
+    responses(
+        (status = 200, description = "Prekey upload successful"),
+        (status = 500, description = "Prekey upload failed unexpectedly")
+    ),
+    tag = KEY_TAG
+)]
+async fn post_prekeys(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<UploadPrekeysRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .key_service
+        .add_prekeys(&req.user_id, req.prekeys)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+
+    Ok(())
+}
+
+#[utoipa::path(
+    get,
+    path = "/keys/bundle/{user_id}",
+    params(
+        ("user_id" = String, Path, description = "User identifier")
+    ),
+    responses(
+        (status = 200, description = "Key bundle retrieved successfully", body = KeyBundleResponse),
+        (status = 500, description = "Key bundle retrieval failed unexpectedly")
+    ),
+    tag = KEY_TAG
+)]
+async fn get_keybundle(
+    Path(user_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .key_service
+        .get_keybundle(&user_id)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use prism_common::account::Account;
 use prism_tree::proofs::HashedMerkleProof;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::common::prism_client::PrismClient;

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -45,7 +45,7 @@ where
     C: PrismClient,
     D: Database,
 {
-    prover: Arc<C>,
+    client: Arc<C>,
     db: Arc<D>,
 }
 
@@ -54,8 +54,8 @@ where
     C: PrismClient,
     D: Database,
 {
-    pub fn new(prover: Arc<C>, db: Arc<D>) -> Self {
-        Self { prover, db }
+    pub fn new(client: Arc<C>, db: Arc<D>) -> Self {
+        Self { client, db }
     }
 
     pub fn upload_key_bundle(&self, user_id: &str, bundle: KeyBundle) -> Result<bool> {
@@ -73,7 +73,7 @@ where
 
     pub async fn get_keybundle(&self, user_id: &str) -> Result<KeyBundleResponse> {
         let keybundle = self.db.get_keybundle(user_id.to_string())?;
-        let account_response = self.prover.get_account(user_id).await?;
+        let account_response = self.client.get_account(user_id).await?;
 
         let response = KeyBundleResponse {
             key_bundle: keybundle,

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use prism_keys::{Signature, VerifyingKey};
+use prism_prover::{prover::AccountResponse, Prover};
+
+use crate::database::Database;
+
+pub struct Prekey {
+    pub key_idx: u32,
+    pub key: VerifyingKey,
+}
+
+/// The complete key bundle contains the long-term identity key,
+/// the signed pre-key (with its signature), and a list of one-time pre-keys.
+pub struct KeyBundle {
+    pub identity_key: VerifyingKey,
+    pub signed_prekey: VerifyingKey,
+    pub signed_prekey_signature: Signature,
+    pub prekeys: Vec<Prekey>,
+}
+
+pub struct KeyBundleResponse {
+    pub key_bundle: KeyBundle,
+    pub account: AccountResponse,
+}
+
+pub struct KeyService {
+    prover: Arc<Prover>,
+    db: Arc<dyn Database>,
+}
+
+impl KeyService {
+    pub fn new(prover: Arc<Prover>, db: Arc<dyn Database>) -> Self {
+        Self { prover, db }
+    }
+
+    // TODO: How do we authenticate
+    pub fn upload_key_bundle(&self, bundle: KeyBundle) -> Result<bool> {
+        unimplemented!()
+    }
+
+    // Note: There is no extra security assumption here: Even if the server is
+    // malicious and adds extra prekeys for a user, the server will still be
+    // unable to decrypt anything, and the receiver simply won't be able to
+    // decrypt the messages either.
+    pub fn add_prekeys(&self, user: &VerifyingKey, prekeys: Vec<Prekey>) -> Result<bool> {
+        unimplemented!()
+    }
+
+    pub fn get_keybundle(&self, user: String) -> Result<KeyBundleResponse> {
+        unimplemented!()
+    }
+}

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use prism_keys::{Signature, VerifyingKey};
 use prism_prover::{prover::AccountResponse, Prover};
 
 use crate::database::Database;
 
+#[derive(Clone)]
 pub struct Prekey {
     pub key_idx: u32,
     pub key: VerifyingKey,
@@ -13,11 +14,20 @@ pub struct Prekey {
 
 /// The complete key bundle contains the long-term identity key,
 /// the signed pre-key (with its signature), and a list of one-time pre-keys.
+#[derive(Clone)]
 pub struct KeyBundle {
     pub identity_key: VerifyingKey,
     pub signed_prekey: VerifyingKey,
     pub signed_prekey_signature: Signature,
     pub prekeys: Vec<Prekey>,
+}
+
+impl KeyBundle {
+    pub fn verify(&self) {
+        // Ensure signature is signed_prekey signed by identity_key
+        // Ensure prekeys have no duplicate IDs
+        todo!()
+    }
 }
 
 pub struct KeyBundleResponse {
@@ -35,20 +45,30 @@ impl KeyService {
         Self { prover, db }
     }
 
-    // TODO: How do we authenticate
-    pub fn upload_key_bundle(&self, bundle: KeyBundle) -> Result<bool> {
-        unimplemented!()
+    pub fn upload_key_bundle(&self, user_id: &str, bundle: KeyBundle) -> Result<bool> {
+        bundle.verify();
+        self.db.insert_keybundle(user_id.to_string(), bundle)
     }
 
     // Note: There is no extra security assumption here: Even if the server is
     // malicious and adds extra prekeys for a user, the server will still be
     // unable to decrypt anything, and the receiver simply won't be able to
     // decrypt the messages either.
-    pub fn add_prekeys(&self, user: &VerifyingKey, prekeys: Vec<Prekey>) -> Result<bool> {
-        unimplemented!()
+    pub fn add_prekeys(&self, user_id: &str, prekeys: Vec<Prekey>) -> Result<bool> {
+        self.db.add_prekeys(user_id.to_string(), prekeys)
     }
 
-    pub fn get_keybundle(&self, user: String) -> Result<KeyBundleResponse> {
-        unimplemented!()
+    pub async fn get_keybundle(&self, user_id: &str) -> Result<KeyBundleResponse> {
+        let keybundle = self.db.get_keybundle(user_id.to_string())?;
+        match keybundle {
+            Some(bundle) => {
+                let account = self.prover.get_account(user_id).await?;
+                Ok(KeyBundleResponse {
+                    key_bundle: bundle,
+                    account,
+                })
+            }
+            None => Err(anyhow!("Key bundle not found")),
+        }
     }
 }

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -2,36 +2,16 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use prism_common::account::Account;
-use prism_keys::{Signature, VerifyingKey};
 use prism_tree::proofs::HashedMerkleProof;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::{common::prism_client::PrismClient, database::Database};
+use crate::common::prism_client::PrismClient;
 
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
-pub struct Prekey {
-    pub key_idx: u32,
-    pub key: VerifyingKey,
-}
-
-/// The complete key bundle contains the long-term identity key,
-/// the signed pre-key (with its signature), and a list of one-time pre-keys.
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
-pub struct KeyBundle {
-    pub identity_key: VerifyingKey,
-    pub signed_prekey: VerifyingKey,
-    pub signed_prekey_signature: Signature,
-    pub prekeys: Vec<Prekey>,
-}
-
-impl KeyBundle {
-    pub fn verify(&self) {
-        // Ensure signature is signed_prekey signed by identity_key
-        // Ensure prekeys have no duplicate IDs
-        todo!()
-    }
-}
+use super::{
+    database::KeyDatabase,
+    entities::{KeyBundle, Prekey},
+};
 
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct KeyBundleResponse {
@@ -43,7 +23,7 @@ pub struct KeyBundleResponse {
 pub struct KeyService<C, D>
 where
     C: PrismClient,
-    D: Database,
+    D: KeyDatabase,
 {
     client: Arc<C>,
     db: Arc<D>,
@@ -52,7 +32,7 @@ where
 impl<C, D> KeyService<C, D>
 where
     C: PrismClient,
-    D: Database,
+    D: KeyDatabase,
 {
     pub fn new(client: Arc<C>, db: Arc<D>) -> Self {
         Self { client, db }

--- a/src/keys/service.rs
+++ b/src/keys/service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use prism_common::account::Account;
 use prism_keys::{Signature, VerifyingKey};
 use prism_prover::{prover::AccountResponse, Prover};
@@ -8,7 +8,7 @@ use prism_tree::proofs::HashedMerkleProof;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::database::{inmemory::InMemoryDatabase, Database};
+use crate::{common::prism_client::PrismClient, database::Database};
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct Prekey {
@@ -41,13 +41,21 @@ pub struct KeyBundleResponse {
     pub proof: HashedMerkleProof,
 }
 
-pub struct KeyService {
-    prover: Arc<Prover>,
-    db: Arc<InMemoryDatabase>,
+pub struct KeyService<C, D>
+where
+    C: PrismClient,
+    D: Database,
+{
+    prover: Arc<C>,
+    db: Arc<D>,
 }
 
-impl KeyService {
-    pub fn new(prover: Arc<Prover>, db: Arc<InMemoryDatabase>) -> Self {
+impl<C, D> KeyService<C, D>
+where
+    C: PrismClient,
+    D: Database,
+{
+    pub fn new(prover: Arc<C>, db: Arc<D>) -> Self {
         Self { prover, db }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,12 @@ use log::debug;
 use prism_common::operation::ServiceChallenge;
 use prism_da::{memory::InMemoryDataAvailabilityLayer, DataAvailabilityLayer};
 use prism_keys::SigningKey;
+use prism_prover::{webserver::WebServerConfig as PrismWebServerConfig, Config, Prover};
 use prism_storage::inmemory::InMemoryDatabase;
 use state::AppState;
 use std::sync::Arc;
 use tokio::spawn;
 use webserver::WebServerConfig;
-
-use prism_prover::{webserver::WebServerConfig as PrismWebServerConfig, Config, Prover};
 
 pub static PRISM_MESSENGER_SERVICE_ID: &str = "prism_messenger";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod account;
 mod common;
+mod database;
+mod keys;
+mod messages;
 mod registration;
 mod state;
 mod webserver;

--- a/src/messages/database.rs
+++ b/src/messages/database.rs
@@ -1,0 +1,9 @@
+use super::service::Message;
+use anyhow::Result;
+use uuid::Uuid;
+
+pub trait MessageDatabase {
+    fn insert_message(&self, message: Message) -> Result<bool>;
+    fn get_messages(&self, user: String) -> Result<Vec<Message>>;
+    fn mark_delivered(&self, user: String, ids: Vec<Uuid>) -> Result<bool>;
+}

--- a/src/messages/database.rs
+++ b/src/messages/database.rs
@@ -1,6 +1,7 @@
-use super::service::Message;
 use anyhow::Result;
 use uuid::Uuid;
+
+use super::entities::Message;
 
 pub trait MessageDatabase {
     fn insert_message(&self, message: Message) -> Result<bool>;

--- a/src/messages/entities.rs
+++ b/src/messages/entities.rs
@@ -1,0 +1,50 @@
+use prism_keys::VerifyingKey;
+
+/// The header provides the recipient with the context needed to update
+/// its ratchet state. It includes the sender’s ephemeral public key and
+/// message counters.
+#[derive(Clone)]
+pub struct DoubleRatchetHeader {
+    /// Sender's ephemeral DH public key for this message
+    pub ephemeral_key: VerifyingKey,
+    /// Message counter within the current chain
+    pub message_number: u64,
+    /// Last message number of the previous chain (for skipped keys)
+    pub previous_message_number: u64,
+    /// Identifier of the one-time prekey used in the handshake
+    pub one_time_prekey_id: Option<u64>,
+}
+
+/// The complete double ratchet message.
+/// The header is bound to the ciphertext via the AEAD process.
+#[derive(Clone)]
+pub struct DoubleRatchetMessage {
+    pub header: DoubleRatchetHeader,
+    /// AEAD-encrypted payload (includes authentication tag)
+    pub ciphertext: Vec<u8>,
+}
+
+/// When sending a message, the sender includes a full double ratchet message.
+/// The server attaches the sender's identity based on the auth token.
+// TODO: How do we authenticate
+pub struct SendMessageRequest {
+    pub recipient_id: String,
+    pub message: DoubleRatchetMessage,
+}
+
+pub struct SendMessageResponse {
+    /// UUID
+    pub message_id: uuid::Uuid,
+    /// Server timestamp (epoch milliseconds)
+    pub timestamp: u64,
+}
+
+/// The message delivered to a client includes sender/recipient metadata.
+#[derive(Clone)]
+pub struct Message {
+    pub message_id: uuid::Uuid,
+    pub sender_id: String,
+    pub recipient_id: String,
+    pub message: DoubleRatchetMessage,
+    pub timestamp: u64,
+}

--- a/src/messages/entities.rs
+++ b/src/messages/entities.rs
@@ -1,9 +1,11 @@
 use prism_keys::VerifyingKey;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// The header provides the recipient with the context needed to update
 /// its ratchet state. It includes the sender’s ephemeral public key and
 /// message counters.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct DoubleRatchetHeader {
     /// Sender's ephemeral DH public key for this message
     pub ephemeral_key: VerifyingKey,
@@ -17,7 +19,7 @@ pub struct DoubleRatchetHeader {
 
 /// The complete double ratchet message.
 /// The header is bound to the ciphertext via the AEAD process.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct DoubleRatchetMessage {
     pub header: DoubleRatchetHeader,
     /// AEAD-encrypted payload (includes authentication tag)
@@ -26,12 +28,15 @@ pub struct DoubleRatchetMessage {
 
 /// When sending a message, the sender includes a full double ratchet message.
 /// The server attaches the sender's identity based on the auth token.
-// TODO: How do we authenticate
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct SendMessageRequest {
+    /// User ID - TODO: Should come from auth, not request body
+    pub sender_id: String,
     pub recipient_id: String,
     pub message: DoubleRatchetMessage,
 }
 
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct SendMessageResponse {
     /// UUID
     pub message_id: uuid::Uuid,
@@ -40,11 +45,18 @@ pub struct SendMessageResponse {
 }
 
 /// The message delivered to a client includes sender/recipient metadata.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct Message {
     pub message_id: uuid::Uuid,
     pub sender_id: String,
     pub recipient_id: String,
     pub message: DoubleRatchetMessage,
     pub timestamp: u64,
+}
+
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+pub struct MarkDeliveredRequest {
+    /// User ID - TODO: Should come from auth, not request body
+    pub user_id: String,
+    pub message_ids: Vec<uuid::Uuid>,
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,2 +1,3 @@
 pub mod database;
+pub mod entities;
 pub mod service;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,1 +1,2 @@
+pub mod database;
 pub mod service;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,3 +1,7 @@
 pub mod database;
 pub mod entities;
 pub mod service;
+
+mod router;
+
+pub use router::router;

--- a/src/messages/router.rs
+++ b/src/messages/router.rs
@@ -7,12 +7,11 @@ use axum::{
 use std::sync::Arc;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use super::entities::{MarkDeliveredRequest, SendMessageRequest};
 use crate::{
     messages::entities::{Message, SendMessageResponse},
     state::AppState,
 };
-
-use super::entities::{MarkDeliveredRequest, SendMessageRequest};
 
 const MESSAGING_TAG: &str = "messaging";
 

--- a/src/messages/router.rs
+++ b/src/messages/router.rs
@@ -1,0 +1,89 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use std::sync::Arc;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::{
+    messages::entities::{Message, SendMessageResponse},
+    state::AppState,
+};
+
+use super::entities::{MarkDeliveredRequest, SendMessageRequest};
+
+const MESSAGING_TAG: &str = "messaging";
+
+pub fn router() -> OpenApiRouter<Arc<AppState>> {
+    OpenApiRouter::new()
+        .routes(routes!(send_message))
+        .routes(routes!(fetch_messages))
+        .routes(routes!(mark_delivered))
+}
+
+#[utoipa::path(
+    post,
+    path = "/send",
+    request_body = SendMessageRequest,
+    responses(
+        (status = 200, description = "Message sent successfully", body = SendMessageResponse),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = MESSAGING_TAG
+)]
+async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SendMessageRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .messaging_service
+        .send_message(req)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[utoipa::path(
+    get,
+    path = "/get/{user_id}",
+    responses(
+        (status = 200, description = "Messages fetched successfully", body = Vec<Message>),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = MESSAGING_TAG
+)]
+async fn fetch_messages(
+    State(state): State<Arc<AppState>>,
+    Path(user_id): Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .messaging_service
+        .get_messages(&user_id)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[utoipa::path(
+    post,
+    path = "/mark-delivered",
+    request_body = MarkDeliveredRequest,
+    responses(
+        (status = 200, description = "Messages marked as delivered successfully", body = bool),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = MESSAGING_TAG
+)]
+async fn mark_delivered(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<MarkDeliveredRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    state
+        .messaging_service
+        .mark_delivered(request)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use prism_keys::VerifyingKey;
 
-use crate::database::{inmemory::InMemoryDatabase, Database};
+use crate::database::Database;
 
 /// The header provides the recipient with the context needed to update
 /// its ratchet state. It includes the sender’s ephemeral public key and
@@ -54,12 +54,12 @@ pub struct Message {
     pub timestamp: u64,
 }
 
-pub struct MessagingService {
-    db: Arc<InMemoryDatabase>,
+pub struct MessagingService<D: Database> {
+    db: Arc<D>,
 }
 
-impl MessagingService {
-    pub fn new(db: Arc<InMemoryDatabase>) -> MessagingService {
+impl<D: Database> MessagingService<D> {
+    pub fn new(db: Arc<D>) -> MessagingService<D> {
         MessagingService { db }
     }
 

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -1,58 +1,11 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use prism_keys::VerifyingKey;
 
-use super::database::MessageDatabase;
-
-/// The header provides the recipient with the context needed to update
-/// its ratchet state. It includes the sender’s ephemeral public key and
-/// message counters.
-#[derive(Clone)]
-pub struct DoubleRatchetHeader {
-    /// Sender's ephemeral DH public key for this message
-    pub ephemeral_key: VerifyingKey,
-    /// Message counter within the current chain
-    pub message_number: u64,
-    /// Last message number of the previous chain (for skipped keys)
-    pub previous_message_number: u64,
-    /// Identifier of the one-time prekey used in the handshake
-    pub one_time_prekey_id: Option<u64>,
-}
-
-/// The complete double ratchet message.
-/// The header is bound to the ciphertext via the AEAD process.
-#[derive(Clone)]
-pub struct DoubleRatchetMessage {
-    pub header: DoubleRatchetHeader,
-    /// AEAD-encrypted payload (includes authentication tag)
-    pub ciphertext: Vec<u8>,
-}
-
-/// When sending a message, the sender includes a full double ratchet message.
-/// The server attaches the sender's identity based on the auth token.
-// TODO: How do we authenticate
-pub struct SendMessageRequest {
-    pub recipient_id: String,
-    pub message: DoubleRatchetMessage,
-}
-
-pub struct SendMessageResponse {
-    /// UUID
-    pub message_id: uuid::Uuid,
-    /// Server timestamp (epoch milliseconds)
-    pub timestamp: u64,
-}
-
-/// The message delivered to a client includes sender/recipient metadata.
-#[derive(Clone)]
-pub struct Message {
-    pub message_id: uuid::Uuid,
-    pub sender_id: String,
-    pub recipient_id: String,
-    pub message: DoubleRatchetMessage,
-    pub timestamp: u64,
-}
+use super::{
+    database::MessageDatabase,
+    entities::{Message, SendMessageRequest, SendMessageResponse},
+};
 
 pub struct MessagingService<D: MessageDatabase> {
     db: Arc<D>,

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 use super::{
     database::MessageDatabase,
-    entities::{Message, SendMessageRequest, SendMessageResponse},
+    entities::{MarkDeliveredRequest, Message, SendMessageRequest, SendMessageResponse},
 };
 
 pub struct MessagingService<D: MessageDatabase> {
@@ -16,15 +16,11 @@ impl<D: MessageDatabase> MessagingService<D> {
         MessagingService { db }
     }
 
-    pub async fn send_message(
-        &self,
-        user_id: &str,
-        request: SendMessageRequest,
-    ) -> Result<SendMessageResponse> {
+    pub async fn send_message(&self, request: SendMessageRequest) -> Result<SendMessageResponse> {
         let timestamp = chrono::Utc::now().timestamp_millis() as u64;
         let message = Message {
             message_id: uuid::Uuid::new_v4(),
-            sender_id: user_id.to_string(),
+            sender_id: request.sender_id.clone(),
             recipient_id: request.recipient_id.clone(),
             message: request.message.clone(),
             timestamp,
@@ -44,7 +40,8 @@ impl<D: MessageDatabase> MessagingService<D> {
         self.db.get_messages(user_id.to_string())
     }
 
-    pub async fn mark_delivered(&self, user_id: &str, msg_ids: Vec<uuid::Uuid>) -> Result<bool> {
-        self.db.mark_delivered(user_id.to_string(), msg_ids)
+    pub async fn mark_delivered(&self, request: MarkDeliveredRequest) -> Result<bool> {
+        self.db
+            .mark_delivered(request.user_id.to_string(), request.message_ids)
     }
 }

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use prism_keys::VerifyingKey;
+
+use crate::database::Database;
+
+/// The header provides the recipient with the context needed to update
+/// its ratchet state. It includes the sender’s ephemeral public key and
+/// message counters.
+pub struct DoubleRatchetHeader {
+    /// Sender's ephemeral DH public key for this message
+    pub ephemeral_key: VerifyingKey,
+    /// Message counter within the current chain
+    pub message_number: u64,
+    /// Last message number of the previous chain (for skipped keys)
+    pub previous_message_number: u64,
+    /// Identifier of the one-time prekey used in the handshake
+    pub one_time_prekey_id: Option<u64>,
+}
+
+/// The complete double ratchet message.
+/// The header is bound to the ciphertext via the AEAD process.
+pub struct DoubleRatchetMessage {
+    pub header: DoubleRatchetHeader,
+    /// AEAD-encrypted payload (includes authentication tag)
+    pub ciphertext: Vec<u8>,
+}
+
+/// When sending a message, the sender includes a full double ratchet message.
+/// The server attaches the sender's identity based on the auth token.
+// TODO: How do we authenticate
+pub struct SendMessageRequest {
+    pub recipient_id: String,
+    pub message: DoubleRatchetMessage,
+}
+
+pub struct SendMessageResponse {
+    /// UUID
+    pub message_id: u64,
+    /// Server timestamp (epoch milliseconds)
+    pub timestamp: u64,
+}
+
+/// The message delivered to a client includes sender/recipient metadata.
+pub struct Message {
+    pub message_id: u64,
+    pub sender_id: String,
+    pub recipient_id: String,
+    pub message: DoubleRatchetMessage,
+    pub timestamp: u64,
+}
+
+pub struct MessagingService {
+    db: Arc<dyn Database>,
+}
+
+impl MessagingService {
+    pub fn new(db: Arc<dyn Database>) -> MessagingService {
+        MessagingService { db }
+    }
+
+    pub async fn send_message(&self, request: SendMessageRequest) -> Result<SendMessageResponse> {
+        unimplemented!()
+    }
+
+    pub async fn get_messages(&self, user_id: String) -> Result<Vec<Message>> {
+        // TODO: When do messages get cleared from the server? How does the client tell the server which messages it's missing?
+        unimplemented!()
+    }
+}

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -44,3 +44,141 @@ impl<D: MessageDatabase> MessagingService<D> {
             .mark_delivered(request.user_id.to_string(), request.message_ids)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use prism_keys::SigningKey;
+    use uuid::Uuid;
+
+    use crate::database::inmemory::InMemoryDatabase;
+
+    use crate::messages::entities::{
+        DoubleRatchetHeader, DoubleRatchetMessage, MarkDeliveredRequest, SendMessageRequest,
+    };
+
+    use super::MessagingService;
+
+    fn init_service() -> Arc<MessagingService<InMemoryDatabase>> {
+        let db = Arc::new(InMemoryDatabase::new());
+        Arc::new(MessagingService::new(db))
+    }
+
+    #[tokio::test]
+    async fn test_send_and_get_message() {
+        let service = init_service();
+        let bob_ephemeral_key = SigningKey::new_secp256r1().verifying_key();
+
+        let header = DoubleRatchetHeader {
+            ephemeral_key: bob_ephemeral_key,
+            message_number: 0,
+            previous_message_number: 0,
+            one_time_prekey_id: Some(0),
+        };
+
+        let message = DoubleRatchetMessage {
+            header,
+            ciphertext: "Hello, Alice".as_bytes().to_vec(),
+        };
+
+        let request = SendMessageRequest {
+            sender_id: "Bob".to_string(),
+            recipient_id: "Alice".to_string(),
+            message,
+        };
+
+        service
+            .send_message(request)
+            .await
+            .expect("Could not send Bob's message to Alice");
+
+        let retrieved_messages = service
+            .get_messages("Alice")
+            .await
+            .expect("Could not fetch message for Alice");
+
+        assert_eq!(retrieved_messages.len(), 1);
+        let alices_msg = retrieved_messages.first().unwrap();
+        assert_eq!(alices_msg.sender_id, "Bob");
+        assert_eq!(alices_msg.recipient_id, "Alice");
+        assert_eq!(
+            alices_msg.message.ciphertext,
+            "Hello, Alice".as_bytes().to_vec()
+        )
+    }
+
+    #[tokio::test]
+    async fn test_set_messages_delivered() {
+        let service = init_service();
+        let bob_ephemeral_key = SigningKey::new_secp256r1().verifying_key();
+
+        let mut requests: Vec<SendMessageRequest> = Vec::new();
+        for i in 0..20 {
+            let new_header = DoubleRatchetHeader {
+                ephemeral_key: bob_ephemeral_key.clone(),
+                message_number: i + 1,
+                previous_message_number: i,
+                one_time_prekey_id: None,
+            };
+            let new_message = DoubleRatchetMessage {
+                header: new_header,
+                ciphertext: format!("Hello, Alice {}", i).as_bytes().to_vec(),
+            };
+
+            let new_request = SendMessageRequest {
+                sender_id: "Bob".to_string(),
+                recipient_id: "Alice".to_string(),
+                message: new_message,
+            };
+            requests.push(new_request);
+        }
+
+        for request in requests {
+            service
+                .send_message(request)
+                .await
+                .expect("Could not send message");
+        }
+
+        let retrieved = service
+            .get_messages("Alice")
+            .await
+            .expect("Could not fetch messages for Alice");
+
+        let uuids: Vec<Uuid> = retrieved.iter().map(|msg| msg.message_id).collect();
+        let delivered = uuids[5..10].to_vec();
+        service
+            .mark_delivered(MarkDeliveredRequest {
+                user_id: "Alice".to_string(),
+                message_ids: delivered.clone(),
+            })
+            .await
+            .expect("Could not set messages delivered");
+
+        let rest = service
+            .get_messages("Alice")
+            .await
+            .expect("Could not fetch messages for Alice");
+        let rest_uuids: Vec<Uuid> = rest.iter().map(|msg| msg.message_id).collect();
+
+        // 15 messages left to mark as delivered
+        assert_eq!(rest_uuids.len(), 15);
+
+        // rest_uuids shouldn't contain any from delivered
+        assert!(!rest_uuids.iter().any(|uuid| delivered.contains(uuid)));
+
+        service
+            .mark_delivered(MarkDeliveredRequest {
+                user_id: "Alice".to_string(),
+                message_ids: rest_uuids,
+            })
+            .await
+            .expect("Could not set messages delivered");
+        let final_messages = service
+            .get_messages("Alice")
+            .await
+            .expect("Could not fetch messages for Alice");
+        assert_eq!(final_messages.len(), 0);
+    }
+}

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
-
 use anyhow::{anyhow, Result};
+use std::sync::Arc;
 
 use super::{
     database::MessageDatabase,

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use prism_keys::VerifyingKey;
 
-use crate::database::Database;
+use crate::database::{inmemory::InMemoryDatabase, Database};
 
 /// The header provides the recipient with the context needed to update
 /// its ratchet state. It includes the sender’s ephemeral public key and
@@ -55,11 +55,11 @@ pub struct Message {
 }
 
 pub struct MessagingService {
-    db: Arc<dyn Database>,
+    db: Arc<InMemoryDatabase>,
 }
 
 impl MessagingService {
-    pub fn new(db: Arc<dyn Database>) -> MessagingService {
+    pub fn new(db: Arc<InMemoryDatabase>) -> MessagingService {
         MessagingService { db }
     }
 

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use prism_keys::VerifyingKey;
 
-use crate::database::Database;
+use super::database::MessageDatabase;
 
 /// The header provides the recipient with the context needed to update
 /// its ratchet state. It includes the sender’s ephemeral public key and
@@ -54,11 +54,11 @@ pub struct Message {
     pub timestamp: u64,
 }
 
-pub struct MessagingService<D: Database> {
+pub struct MessagingService<D: MessageDatabase> {
     db: Arc<D>,
 }
 
-impl<D: Database> MessagingService<D> {
+impl<D: MessageDatabase> MessagingService<D> {
     pub fn new(db: Arc<D>) -> MessagingService<D> {
         MessagingService { db }
     }

--- a/src/registration/service.rs
+++ b/src/registration/service.rs
@@ -1,10 +1,10 @@
+use anyhow::Result;
+use prism_common::{digest::Digest, operation::ServiceChallengeInput};
+use prism_keys::{SigningKey, VerifyingKey};
 use std::sync::Arc;
 
 use crate::common::prism_client::PrismClient;
 use crate::PRISM_MESSENGER_SERVICE_ID;
-use anyhow::Result;
-use prism_common::{digest::Digest, operation::ServiceChallengeInput};
-use prism_keys::{SigningKey, VerifyingKey};
 
 pub struct RegistrationService<C: PrismClient> {
     prism: Arc<C>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
-
 use prism_keys::SigningKey;
 use prism_prover::Prover;
+use std::sync::Arc;
 
 use crate::{
     account::service::AccountService, database::inmemory::InMemoryDatabase,

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,14 +11,15 @@ use crate::{
 
 pub struct AppState {
     pub account_service: AccountService<Prover>,
-    pub key_service: KeyService,
-    pub messaging_service: MessagingService,
+    pub key_service: KeyService<Prover, InMemoryDatabase>,
+    pub messaging_service: MessagingService<InMemoryDatabase>,
     pub registration_service: RegistrationService<Prover>,
 }
 
 impl AppState {
     pub fn new(prover: Arc<Prover>, signing_key: SigningKey) -> Self {
         let db = Arc::new(InMemoryDatabase::new());
+
         let account_service = AccountService::new(prover.clone());
         let registration_service = RegistrationService::new(prover.clone(), signing_key);
         let key_service = KeyService::new(prover.clone(), db.clone());

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,21 +3,32 @@ use std::sync::Arc;
 use prism_keys::SigningKey;
 use prism_prover::Prover;
 
-use crate::{account::service::AccountService, registration::service::RegistrationService};
+use crate::{
+    account::service::AccountService, database::inmemory::InMemoryDatabase,
+    keys::service::KeyService, messages::service::MessagingService,
+    registration::service::RegistrationService,
+};
 
 pub struct AppState {
     pub account_service: AccountService<Prover>,
+    pub key_service: KeyService,
+    pub messaging_service: MessagingService,
     pub registration_service: RegistrationService<Prover>,
 }
 
 impl AppState {
     pub fn new(prover: Arc<Prover>, signing_key: SigningKey) -> Self {
+        let db = Arc::new(InMemoryDatabase::new());
         let account_service = AccountService::new(prover.clone());
         let registration_service = RegistrationService::new(prover.clone(), signing_key);
+        let key_service = KeyService::new(prover.clone(), db.clone());
+        let messaging_service = MessagingService::new(db.clone());
 
         Self {
             account_service,
             registration_service,
+            key_service,
+            messaging_service,
         }
     }
 }

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,4 +1,3 @@
-use crate::{account, keys, messages, registration, state::AppState};
 use anyhow::{Context, Result};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -11,6 +10,8 @@ use utoipa::{
 };
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_swagger_ui::SwaggerUi;
+
+use crate::{account, keys, messages, registration, state::AppState};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WebServerConfig {

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,3 +1,4 @@
+use crate::{account, keys, registration, state::AppState};
 use anyhow::{Context, Result};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -10,11 +11,6 @@ use utoipa::{
 };
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_swagger_ui::SwaggerUi;
-
-use crate::state::AppState;
-
-use super::account;
-use super::registration;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WebServerConfig {
@@ -37,6 +33,7 @@ struct ApiDoc;
 pub async fn start(config: &WebServerConfig, state: AppState) -> Result<()> {
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .nest("/accounts", account::router())
+        .nest("/keys", keys::router())
         .merge(registration::router())
         .with_state(Arc::new(state))
         .layer(CorsLayer::permissive())

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,4 +1,4 @@
-use crate::{account, keys, registration, state::AppState};
+use crate::{account, keys, messages, registration, state::AppState};
 use anyhow::{Context, Result};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,7 @@ pub async fn start(config: &WebServerConfig, state: AppState) -> Result<()> {
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .nest("/accounts", account::router())
         .nest("/keys", keys::router())
+        .nest("/messages", messages::router())
         .merge(registration::router())
         .with_state(Arc::new(state))
         .layer(CorsLayer::permissive())


### PR DESCRIPTION
Just uploading before I sign off for the night. Cannot build because we need to merge jonas' PR upstream for utoipa, so a bit blocked until then

Realizations:
1. We need to determine how we want to do auth before we can flesh this out
2. We need to make a clean database interface. Let's not overoptimize here, its okay if its inefficient
3. The biggest weak point of the current stubs is the message retrieval: We need to figure out the mechanism to deliver only the missing messages from the client. Might have to model the entire thing slightly differently here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added API endpoints for key management, allowing users to upload and retrieve secure key bundles.
	- Introduced messaging capabilities enabling sending, fetching, and marking messages as delivered.
- **Chores**
	- Updated and enhanced dependencies for improved UUID generation and time handling.
- **Refactor**
	- Reorganized module structure and optimized import ordering to improve overall code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->