### PR TITLE
feat: adding nonce to msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,7 +6219,6 @@ dependencies = [
 name = "prism-keys"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
  "anyhow",
  "ed25519-consensus",
  "getrandom 0.2.15",
@@ -6227,9 +6226,7 @@ dependencies = [
  "p256",
  "prism-serde",
  "rand 0.8.5",
- "ripemd",
  "serde",
- "serde_json",
  "sha2 0.10.8",
  "utoipa",
 ]
@@ -6291,7 +6288,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bech32",
  "bincode",
  "hex",
  "serde",

--- a/src/keys/entities.rs
+++ b/src/keys/entities.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use prism_client::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/src/messages/entities.rs
+++ b/src/messages/entities.rs
@@ -1,5 +1,6 @@
 use prism_client::VerifyingKey;
 use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
 use utoipa::ToSchema;
 
 /// The header provides the recipient with the context needed to update
@@ -20,12 +21,16 @@ pub struct DoubleRatchetHeader {
 
 /// The complete double ratchet message.
 /// The header is bound to the ciphertext via the AEAD process.
+#[serde_as]
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DoubleRatchetMessage {
     pub header: DoubleRatchetHeader,
     /// AEAD-encrypted payload (includes authentication tag)
+    #[serde_as(as = "Base64")]
     pub ciphertext: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    pub nonce: Vec<u8>,
 }
 
 /// When sending a message, the sender includes a full double ratchet message.

--- a/src/messages/service.rs
+++ b/src/messages/service.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::sync::Arc;
 
 use super::{
@@ -80,6 +80,7 @@ mod tests {
         let message = DoubleRatchetMessage {
             header,
             ciphertext: "Hello, Alice".as_bytes().to_vec(),
+            nonce: vec![0; 12],
         };
 
         let request = SendMessageRequest {
@@ -124,6 +125,7 @@ mod tests {
             let new_message = DoubleRatchetMessage {
                 header: new_header,
                 ciphertext: format!("Hello, Alice {}", i).as_bytes().to_vec(),
+                nonce: vec![0; 12],
             };
 
             let new_request = SendMessageRequest {


### PR DESCRIPTION
For compatibility w app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced message serialization by encoding binary data with Base64, ensuring more reliable transmission of encrypted messages.
- **Bug Fixes**
	- Updated test cases to include a `nonce` field in the `DoubleRatchetMessage` struct, improving test coverage.
- **Chores**
	- Reordered import statements for clarity in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->