### PR TITLE
fix: specify correct separator for env variables

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,7 +43,7 @@ impl Settings {
     pub fn load() -> Result<Settings, ConfigError> {
         let settings = Config::builder()
             .add_source(config::File::with_name("settings"))
-            .add_source(config::Environment::with_prefix("PRISM_MSG_"))
+            .add_source(config::Environment::with_prefix("PRISM_MSG").separator("_"))
             .build()?;
 
         settings.try_deserialize()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated environment variable handling to use a more explicit separator, improving consistency in how settings are loaded from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->