### PR TITLE
feat: improved env separators

### DIFF
--- a/settings.example.toml
+++ b/settings.example.toml
@@ -7,12 +7,12 @@ port = 44444
 [prism]
 host = "127.0.0.1"
 port = 55555
-signing_key_path = "~/.prism/PrismMessengerServer_SigningKey.p8"
+signing_key = "~/.prism/PrismMessengerServer_SigningKey.p8"
 
 [apns]
 team_id = "T1E234A5M"
 key_id = "K12E34Y56"
-private_key_path = "~/.prism/AuthKey_K12E34Y56.p8"
+private_key = "~/.prism/AuthKey_K12E34Y56.p8"
 bundle_id = "com.whatever.PrismMessenger"
 
 [database]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,7 @@ pub struct WebserverSettings {
 pub struct PrismSettings {
     pub host: String,
     pub port: u16,
+    #[serde(rename = "signing_key")]
     pub signing_key_path: String,
 }
 
@@ -21,6 +22,7 @@ pub struct ApnsSettings {
     pub team_id: String,
     pub key_id: String,
     pub bundle_id: String,
+    #[serde(rename = "private_key")]
     pub private_key_path: String,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -45,7 +45,7 @@ impl Settings {
     pub fn load() -> Result<Settings, ConfigError> {
         let settings = Config::builder()
             .add_source(File::with_name("settings"))
-            .add_source(Environment::with_prefix("PRISM_MSG").separator("_"))
+            .add_source(Environment::with_prefix("PRISM_MSG").separator("__"))
             .build()?;
 
         settings.try_deserialize()
@@ -54,7 +54,7 @@ impl Settings {
     pub fn load_from_path(path: impl AsRef<Path>) -> Result<Settings, ConfigError> {
         let settings = Config::builder()
             .add_source(File::from(path.as_ref()))
-            .add_source(Environment::with_prefix("PRISM_MSG").separator("_"))
+            .add_source(Environment::with_prefix("PRISM_MSG").separator("__"))
             .build()?;
 
         settings.try_deserialize()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration key names in the settings file for improved clarity.
	- Changed the environment variable separator for configuration loading to use double underscores (`__`) instead of a single underscore (`_`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->